### PR TITLE
DATA-6781: Adding two extra fields to the campaigns schema

### DIFF
--- a/tap_activecampaign/schemas/campaigns.json
+++ b/tap_activecampaign/schemas/campaigns.json
@@ -272,6 +272,12 @@
     },
     "automation": {
       "type": ["null", "integer"]
+    },
+    "verified_opens": {
+      "type": ["null", "integer"]
+    },
+    "verified_unique_opens": {
+      "type": ["null", "integer"]
     }
   }
 }


### PR DESCRIPTION
It has been discovered that two relevant fields, VERIFIED_OPENS and VERIFIED_UNIQUE_OPENS, were not previously included in the campaign schema. This issue can be addressed with a minor fix - updating the tap V3 schema.