### PR TITLE
AN-162: three more extra V1 reports were added

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ spec](https://github.com/singer-io/getting-started/blob/master/SPEC.md).
 
 This tap:
 
-- Pulls raw data from the [ActiveCampaign v3 API](https://developers.activecampaign.com/reference#overview)
+- Pulls raw data from the [ActiveCampaign v3 API](https://developers.activecampaign.com/reference#overview) and the [ActiveCampaign v1 API](https://www.activecampaign.com/api/overview.php)
 - Extracts the following resources:
   - [accounts](https://developers.activecampaign.com/reference/list-all-accounts)
   - [account_contacts](https://developers.activecampaign.com/reference/list-all-associations-1)
@@ -30,6 +30,10 @@ This tap:
   - [deal_groups](https://developers.activecampaign.com/reference/list-all-pipelines)
   - [deal_custom_fields](https://developers.activecampaign.com/reference/retrieve-all-custom-deal-field-meta)
   - [deal_custom_field_values](https://developers.activecampaign.com/reference/list-all-custom-fielddata-field-values)
+  - [campaign_report_open_list](https://www.activecampaign.com/api/example.php?call=campaign_report_open_list) *(V1 API)*
+  - [campaign_report_unopen_list](https://www.activecampaign.com/api/example.php?call=campaign_report_unopen_list) *(V1 API)*
+  - [campaign_report_bounce_list](https://www.activecampaign.com/api/example.php?call=campaign_report_bounce_list) *(V1 API)*
+  - [campaign_report_unsubscription_list](https://www.activecampaign.com/api/example.php?call=campaign_report_unsubscription_list) *(V1 API)*
 
 
 
@@ -210,7 +214,79 @@ This tap:
   - Bookmark: mdate
 - Transformations: camelCase to snake_case, remove links node
 
+[campaign_messages](https://developers.activecampaign.com/reference/list-all-campaigns)
+- Endpoint: https://{subdomain}.api-us1.com/campaignMessages
+- Data key: campaignMessages
+- Primary keys: id
+- Replication strategy: Full Table
+- Transformations: camelCase to snake_case, remove links node
+- Note: Each record represents a message (email variant) within a campaign, with per-message delivery and engagement stats (`send_amt`, `opens`, `uniqueopens`, `linkclicks`, `hardbounces`, `softbounces`, `unsubscribes`, etc.). The `messageid` and `campaignid` fields are the inputs required by the `campaign_report_unopen_list` V1 stream — query this stream first to build the `campaign_messages` pairs for that config.
 
+[campaign_report_open_list](https://www.activecampaign.com/api/example.php?call=campaign_report_open_list)
+- Endpoint: V1 API — `/admin/api.php?api_action=campaign_report_open_list`
+- Primary keys: subscriberid, campaignid
+- Replication strategy: Incremental
+  - Bookmark: tstamp (1-day overlap applied)
+- Requires: `extra_params.campaigns` (list of campaign IDs)
+- Transformations: numeric-keyed V1 response flattened to list
+
+[campaign_report_unopen_list](https://www.activecampaign.com/api/example.php?call=campaign_report_unopen_list)
+- Endpoint: V1 API — `/admin/api.php?api_action=campaign_report_unopen_list`
+- Primary keys: subscriberid, campaignid
+- Replication strategy: Incremental
+  - Bookmark: tstamp (1-day overlap applied)
+- Requires: `extra_params.campaign_messages` (list of `[campaignid, messageid]` pairs — both are required by this endpoint)
+- Transformations: numeric-keyed V1 response flattened to list
+
+[campaign_report_bounce_list](https://www.activecampaign.com/api/example.php?call=campaign_report_bounce_list)
+- Endpoint: V1 API — `/admin/api.php?api_action=campaign_report_bounce_list`
+- Primary keys: id, campaignid
+- Replication strategy: Incremental
+  - Bookmark: tstamp (1-day overlap applied)
+- Requires: `extra_params.campaigns` (list of campaign IDs)
+- Transformations: numeric-keyed V1 response flattened to list
+
+[campaign_report_unsubscription_list](https://www.activecampaign.com/api/example.php?call=campaign_report_unsubscription_list)
+- Endpoint: V1 API — `/admin/api.php?api_action=campaign_report_unsubscription_list`
+- Primary keys: subscriberid, campaignid
+- Replication strategy: Incremental
+  - Bookmark: tstamp (1-day overlap applied)
+- Requires: `extra_params.campaigns` (list of campaign IDs)
+- Transformations: numeric-keyed V1 response flattened to list
+
+## V1 Campaign Report Streams — Configuration
+
+The four `campaign_report_*` streams use the legacy V1 API and require additional parameters in `config.json` under `extra_params`.
+
+**For `campaign_report_open_list`, `campaign_report_bounce_list`, `campaign_report_unsubscription_list`:**
+
+```json
+{
+  "api_url": "https://<account>.api-us1.com",
+  "api_token": "<token>",
+  "start_date": "2024-01-01T00:00:00Z",
+  "extra_params": {
+    "campaigns": [123, 456, 789]
+  }
+}
+```
+
+**For `campaign_report_unopen_list`** (requires both campaign ID and message ID per request):
+
+```json
+{
+  "api_url": "https://<account>.api-us1.com",
+  "api_token": "<token>",
+  "start_date": "2024-01-01T00:00:00Z",
+  "extra_params": {
+    "campaign_messages": [[123, 10], [123, 20], [456, 30]]
+  }
+}
+```
+
+Each entry in `campaign_messages` is a `[campaignid, messageid]` pair. You can find message IDs from the `campaign_messages` stream (v3 API).
+
+Optional: add `"parallel_threads": 4` to `extra_params` to control the thread pool size for concurrent campaign fetching (default: Python's `min(32, cpu_count + 4)`).
 
 ## Authentication
 

--- a/tap_activecampaign/schemas/campaign_report_bounce_list.json
+++ b/tap_activecampaign/schemas/campaign_report_bounce_list.json
@@ -1,0 +1,43 @@
+{
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "id": {
+        "type": ["null", "integer"]
+      },
+      "email": {
+        "type": ["null", "string"]
+      },
+      "subscriberid": {
+        "type": ["null", "integer"]
+      },
+      "listid": {
+        "type": ["null", "integer"]
+      },
+      "campaignid": {
+        "type": ["null", "integer"]
+      },
+      "messageid": {
+        "type": ["null", "integer"]
+      },
+      "tstamp": {
+        "type": ["null", "string"],
+        "format": "date-time"
+      },
+      "type": {
+        "type": ["null", "string"]
+      },
+      "code": {
+        "type": ["null", "string"]
+      },
+      "counted": {
+        "type": ["null", "integer"]
+      },
+      "reason": {
+        "type": ["null", "string"]
+      },
+      "descript": {
+        "type": ["null", "string"]
+      }
+    }
+}

--- a/tap_activecampaign/schemas/campaign_report_unopen_list.json
+++ b/tap_activecampaign/schemas/campaign_report_unopen_list.json
@@ -1,0 +1,25 @@
+{
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "tstamp": {
+        "type": ["null", "string"],
+        "format": "date-time"
+      },
+      "tstamp_iso": {
+        "type": ["null", "string"]
+      },
+      "subscriberid": {
+        "type": ["null", "integer"]
+      },
+      "email": {
+        "type": ["null", "string"]
+      },
+      "campaignid": {
+        "type": ["null", "integer"]
+      },
+      "messageid": {
+        "type": ["null", "integer"]
+      }
+    }
+}

--- a/tap_activecampaign/schemas/campaign_report_unsubscription_list.json
+++ b/tap_activecampaign/schemas/campaign_report_unsubscription_list.json
@@ -1,0 +1,32 @@
+{
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "tstamp": {
+        "type": ["null", "string"],
+        "format": "date-time"
+      },
+      "tstamp_iso": {
+        "type": ["null", "string"]
+      },
+      "udate": {
+        "type": ["null", "string"],
+        "format": "date-time"
+      },
+      "udate_iso": {
+        "type": ["null", "string"]
+      },
+      "subscriberid": {
+        "type": ["null", "integer"]
+      },
+      "email": {
+        "type": ["null", "string"]
+      },
+      "unsubreason": {
+        "type": ["null", "string"]
+      },
+      "campaignid": {
+        "type": ["null", "integer"]
+      }
+    }
+}

--- a/tap_activecampaign/streams.py
+++ b/tap_activecampaign/streams.py
@@ -619,7 +619,7 @@ class Campaign_report_open_list(ActiveCampaign):
         ):
             params = {
                 "page": page,
-                "campaignid": campaignid,
+                **self._campaign_params(campaignid),
                 **static_params,  # adds in endpoint specific, sort, filter params
             }
 
@@ -634,7 +634,7 @@ class Campaign_report_open_list(ActiveCampaign):
             )
 
             LOGGER.info(
-                "URL for Stream {}: {}{}{}".format(
+                "URL for Stream {}: {}/{}{}".format(
                     self.stream_name,
                     self.client.base_url,
                     path,
@@ -675,6 +675,9 @@ class Campaign_report_open_list(ActiveCampaign):
             )
 
         return max_bookmark_value, endpoint_total
+
+    def _campaign_params(self, campaignid):
+        return {"campaignid": campaignid}
 
     def transform_data(self, data):
         """
@@ -722,6 +725,57 @@ class Campaign_report_open_list(ActiveCampaign):
         state["bookmarks"][stream] = value
         LOGGER.info("Write state for stream: {}, value: {}".format(stream, value))
         singer.write_state(state)
+
+
+class Campaign_report_unopen_list(Campaign_report_open_list):
+    """
+    View all unopens for a specific campaign.
+    Reference: https://www.activecampaign.com/api/example.php?call=campaign_report_unopen_list
+    """
+    stream_name = "campaign_report_unopen_list"
+    path = "campaign_report_unopen_list"
+    data_key = "campaign_report_unopen_list_v1"
+    params = {}
+    key_properties = ["subscriberid", "campaignid", "messageid"]
+    extra_fields = ["campaignid", "messageid"]
+
+    def sync(self, client, catalog, state, start_date, path,
+             selected_streams=None, parent=None, parent_id=None, **kwargs):
+        campaign_messages = kwargs.get("campaign_messages", [])
+        if not campaign_messages:
+            LOGGER.warning("campaign_report_unopen_list: no 'campaign_messages' in extra_params, skipping sync")
+            return 0
+        kwargs["campaigns"] = campaign_messages
+        return super().sync(client, catalog, state, start_date, path,
+                            selected_streams, parent, parent_id, **kwargs)
+
+    def _campaign_params(self, campaign_message_pair):
+        campaignid, messageid = campaign_message_pair
+        return {"campaignid": campaignid, "messageid": messageid}
+
+
+class Campaign_report_bounce_list(Campaign_report_open_list):
+    """
+    View all bounces for a specific campaign.
+    Reference: https://www.activecampaign.com/api/example.php?call=campaign_report_bounce_list
+    """
+    stream_name = "campaign_report_bounce_list"
+    path = "campaign_report_bounce_list"
+    data_key = "campaign_report_bounce_list_v1"
+    key_properties = ["campaignid", "subscriberid", "messageid"]
+    extra_fields = []
+    params = {}
+
+
+class Campaign_report_unsubscription_list(Campaign_report_open_list):
+    """
+    View all unsubscriptions for a specific campaign.
+    Reference: https://www.activecampaign.com/api/example.php?call=campaign_report_unsubscription_list
+    """
+    stream_name = "campaign_report_unsubscription_list"
+    path = "campaign_report_unsubscription_list"
+    data_key = "campaign_report_unsubscription_list_v1"
+    params = {}
 
 
 class Accounts(ActiveCampaign):
@@ -1348,6 +1402,9 @@ class Sms(ActiveCampaign):
 
 STREAMS = {
     'campaign_report_open_list': Campaign_report_open_list,
+    'campaign_report_unopen_list': Campaign_report_unopen_list,
+    'campaign_report_bounce_list': Campaign_report_bounce_list,
+    'campaign_report_unsubscription_list': Campaign_report_unsubscription_list,
     'accounts': Accounts,
     'account_contacts': AccountContact,
     'account_custom_fields': AccountCustomFields,

--- a/tests/unittests/test_params_for_campaign_report_bounce_list.py
+++ b/tests/unittests/test_params_for_campaign_report_bounce_list.py
@@ -1,0 +1,139 @@
+import requests
+from tap_activecampaign.streams import Campaign_report_bounce_list
+from tap_activecampaign.client_v1 import ActiveCampaignClientV1
+import unittest
+from unittest import mock
+
+
+class Mockresponse:
+    def __init__(self, status_code, json, raise_error, headers=None):
+        self.status_code = status_code
+        self.raise_error = raise_error
+        self.text = json
+        self.headers = headers
+
+    def raise_for_status(self):
+        if not self.raise_error:
+            return self.status_code
+        raise requests.HTTPError("Sample message")
+
+    def json(self):
+        return self.text
+
+
+def get_response(status_code, json={}, raise_error=False, headers=None):
+    return Mockresponse(status_code, json, raise_error, headers)
+
+
+class TestCampaignReportBounceListParams(unittest.TestCase):
+    @mock.patch("requests.Session.request")
+    @mock.patch("tap_activecampaign.streams.Campaign_report_bounce_list.process_records")
+    def test_stream_params(self, mocked_process_records, mocked_request):
+        mocked_request.side_effect = [
+            get_response(
+                200,
+                """<?xml version='1.0' encoding='utf-8'?>
+                    <not_allowed><error>You are not authorized to access this file</error></not_allowed>
+                """
+            ),
+            get_response(
+                200,
+                {
+                    "0": {
+                        "id": "1",
+                        "subscriberid": "111",
+                        "email": "test01@gmail.com",
+                        "campaignid": "123",
+                        "messageid": "10",
+                        "listid": "5",
+                        "tstamp": "2023-08-28",
+                        "type": "hard",
+                        "code": "5.1.1",
+                        "counted": "1",
+                        "reason": "user_unknown",
+                        "descript": "User unknown",
+                    },
+                    "1": {
+                        "id": "2",
+                        "subscriberid": "222",
+                        "email": "test02@gmail.com",
+                        "campaignid": "123",
+                        "messageid": "10",
+                        "listid": "5",
+                        "tstamp": "2023-08-29",
+                        "type": "soft",
+                        "code": "4.2.2",
+                        "counted": "1",
+                        "reason": "mailbox_full",
+                        "descript": "Mailbox full",
+                    },
+                    "result_code": 1,
+                    "result_message": "Success: Something is returned",
+                    "result_output": "json",
+                },
+            ),
+            get_response(
+                200,
+                {
+                    "0": {
+                        "id": "3",
+                        "subscriberid": "333",
+                        "email": "test03@gmail.com",
+                        "campaignid": "123",
+                        "messageid": "10",
+                        "listid": "5",
+                        "tstamp": "2023-08-30",
+                        "type": "hard",
+                        "code": "5.1.1",
+                        "counted": "1",
+                        "reason": "user_unknown",
+                        "descript": "User unknown",
+                    },
+                    "1": {
+                        "id": "4",
+                        "subscriberid": "444",
+                        "email": "test04@gmail.com",
+                        "campaignid": "123",
+                        "messageid": "10",
+                        "listid": "5",
+                        "tstamp": "2023-08-31",
+                        "type": "soft",
+                        "code": "4.2.2",
+                        "counted": "0",
+                        "reason": "mailbox_full",
+                        "descript": "Mailbox full",
+                    },
+                    "result_code": 1,
+                    "result_message": "Success: Something is returned",
+                    "result_output": "json",
+                },
+            ),
+            get_response(
+                200,
+                {
+                    "result_code": 0,
+                    "result_message": "Failed: Nothing is returned",
+                    "result_output": "json",
+                },
+            ),
+        ]
+
+        mocked_process_records.side_effect = [("2023-08-28", 2), ("2023-08-28", 2)]
+
+        client = ActiveCampaignClientV1("test_client_id", "test_client_secret", "test_refresh_token")
+        stream = Campaign_report_bounce_list(client=client)
+        total_extracted_entries = stream.sync(
+            client,
+            {},
+            {},
+            "2022-04-01",
+            stream.path,
+            ["campaign_report_bounce_list"],
+            campaigns=[123],
+        )
+
+        args, kwargs = mocked_request.call_args
+        params = kwargs.get("params")
+
+        self.assertTrue("page=3&campaignid=123" in params)
+        self.assertEqual(total_extracted_entries, 4)

--- a/tests/unittests/test_params_for_campaign_report_unopen_list.py
+++ b/tests/unittests/test_params_for_campaign_report_unopen_list.py
@@ -1,0 +1,107 @@
+import requests
+from tap_activecampaign.streams import Campaign_report_unopen_list
+from tap_activecampaign.client_v1 import ActiveCampaignClientV1
+import unittest
+from unittest import mock
+
+
+class Mockresponse:
+    def __init__(self, status_code, json, raise_error, headers=None):
+        self.status_code = status_code
+        self.raise_error = raise_error
+        self.text = json
+        self.headers = headers
+
+    def raise_for_status(self):
+        if not self.raise_error:
+            return self.status_code
+        raise requests.HTTPError("Sample message")
+
+    def json(self):
+        return self.text
+
+
+def get_response(status_code, json={}, raise_error=False, headers=None):
+    return Mockresponse(status_code, json, raise_error, headers)
+
+
+class TestCampaignReportUnopenListParams(unittest.TestCase):
+    @mock.patch("requests.Session.request")
+    @mock.patch("tap_activecampaign.streams.Campaign_report_unopen_list.process_records")
+    def test_stream_params(self, mocked_process_records, mocked_request):
+        mocked_request.side_effect = [
+            get_response(
+                200,
+                """<?xml version='1.0' encoding='utf-8'?>
+                    <not_allowed><error>You are not authorized to access this file</error></not_allowed>
+                """
+            ),
+            get_response(
+                200,
+                {
+                    "0": {
+                        "subscriberid": "111",
+                        "email": "test01@gmail.com",
+                        "tstamp": "2023-08-28 08:37:19",
+                        "tstamp_iso": "2023-08-28T07:37:19-05:00",
+                    },
+                    "1": {
+                        "subscriberid": "222",
+                        "email": "test02@gmail.com",
+                        "tstamp": "2023-08-29 08:37:19",
+                        "tstamp_iso": "2023-08-29T07:37:19-05:00",
+                    },
+                    "result_code": 1,
+                    "result_message": "Success: Something is returned",
+                    "result_output": "json",
+                },
+            ),
+            get_response(
+                200,
+                {
+                    "0": {
+                        "subscriberid": "333",
+                        "email": "test03@gmail.com",
+                        "tstamp": "2023-08-30 08:37:19",
+                        "tstamp_iso": "2023-08-30T07:37:19-05:00",
+                    },
+                    "1": {
+                        "subscriberid": "444",
+                        "email": "test04@gmail.com",
+                        "tstamp": "2023-08-31 08:37:19",
+                        "tstamp_iso": "2023-08-31T07:37:19-05:00",
+                    },
+                    "result_code": 1,
+                    "result_message": "Success: Something is returned",
+                    "result_output": "json",
+                },
+            ),
+            get_response(
+                200,
+                {
+                    "result_code": 0,
+                    "result_message": "Failed: Nothing is returned",
+                    "result_output": "json",
+                },
+            ),
+        ]
+
+        mocked_process_records.side_effect = [("2023-08-28", 2), ("2023-08-28", 2)]
+
+        client = ActiveCampaignClientV1("test_client_id", "test_client_secret", "test_refresh_token")
+        stream = Campaign_report_unopen_list(client=client)
+        total_extracted_entries = stream.sync(
+            client,
+            {},
+            {},
+            "2022-04-01",
+            stream.path,
+            ["campaign_report_unopen_list"],
+            campaign_messages=[[123, 10]],
+        )
+
+        args, kwargs = mocked_request.call_args
+        params = kwargs.get("params")
+
+        self.assertTrue("page=3&campaignid=123&messageid=10" in params)
+        self.assertEqual(total_extracted_entries, 4)

--- a/tests/unittests/test_params_for_campaign_report_unsubscription_list.py
+++ b/tests/unittests/test_params_for_campaign_report_unsubscription_list.py
@@ -1,0 +1,119 @@
+import requests
+from tap_activecampaign.streams import Campaign_report_unsubscription_list
+from tap_activecampaign.client_v1 import ActiveCampaignClientV1
+import unittest
+from unittest import mock
+
+
+class Mockresponse:
+    def __init__(self, status_code, json, raise_error, headers=None):
+        self.status_code = status_code
+        self.raise_error = raise_error
+        self.text = json
+        self.headers = headers
+
+    def raise_for_status(self):
+        if not self.raise_error:
+            return self.status_code
+        raise requests.HTTPError("Sample message")
+
+    def json(self):
+        return self.text
+
+
+def get_response(status_code, json={}, raise_error=False, headers=None):
+    return Mockresponse(status_code, json, raise_error, headers)
+
+
+class TestCampaignReportUnsubscriptionListParams(unittest.TestCase):
+    @mock.patch("requests.Session.request")
+    @mock.patch("tap_activecampaign.streams.Campaign_report_unsubscription_list.process_records")
+    def test_stream_params(self, mocked_process_records, mocked_request):
+        mocked_request.side_effect = [
+            get_response(
+                200,
+                """<?xml version='1.0' encoding='utf-8'?>
+                    <not_allowed><error>You are not authorized to access this file</error></not_allowed>
+                """
+            ),
+            get_response(
+                200,
+                {
+                    "0": {
+                        "subscriberid": "111",
+                        "email": "test01@gmail.com",
+                        "tstamp": "2023-08-28 08:37:19",
+                        "tstamp_iso": "2023-08-28T07:37:19-05:00",
+                        "udate": "2023-08-28 08:37:19",
+                        "udate_iso": "2023-08-28T07:37:19-05:00",
+                        "unsubreason": "No longer interested",
+                    },
+                    "1": {
+                        "subscriberid": "222",
+                        "email": "test02@gmail.com",
+                        "tstamp": "2023-08-29 08:37:19",
+                        "tstamp_iso": "2023-08-29T07:37:19-05:00",
+                        "udate": "2023-08-29 08:37:19",
+                        "udate_iso": "2023-08-29T07:37:19-05:00",
+                        "unsubreason": "Too many emails",
+                    },
+                    "result_code": 1,
+                    "result_message": "Success: Something is returned",
+                    "result_output": "json",
+                },
+            ),
+            get_response(
+                200,
+                {
+                    "0": {
+                        "subscriberid": "333",
+                        "email": "test03@gmail.com",
+                        "tstamp": "2023-08-30 08:37:19",
+                        "tstamp_iso": "2023-08-30T07:37:19-05:00",
+                        "udate": "2023-08-30 08:37:19",
+                        "udate_iso": "2023-08-30T07:37:19-05:00",
+                        "unsubreason": "",
+                    },
+                    "1": {
+                        "subscriberid": "444",
+                        "email": "test04@gmail.com",
+                        "tstamp": "2023-08-31 08:37:19",
+                        "tstamp_iso": "2023-08-31T07:37:19-05:00",
+                        "udate": "2023-08-31 08:37:19",
+                        "udate_iso": "2023-08-31T07:37:19-05:00",
+                        "unsubreason": "Spam",
+                    },
+                    "result_code": 1,
+                    "result_message": "Success: Something is returned",
+                    "result_output": "json",
+                },
+            ),
+            get_response(
+                200,
+                {
+                    "result_code": 0,
+                    "result_message": "Failed: Nothing is returned",
+                    "result_output": "json",
+                },
+            ),
+        ]
+
+        mocked_process_records.side_effect = [("2023-08-28", 2), ("2023-08-28", 2)]
+
+        client = ActiveCampaignClientV1("test_client_id", "test_client_secret", "test_refresh_token")
+        stream = Campaign_report_unsubscription_list(client=client)
+        total_extracted_entries = stream.sync(
+            client,
+            {},
+            {},
+            "2022-04-01",
+            stream.path,
+            ["campaign_report_unsubscription_list"],
+            campaigns=[123],
+        )
+
+        args, kwargs = mocked_request.call_args
+        params = kwargs.get("params")
+
+        self.assertTrue("page=3&campaignid=123" in params)
+        self.assertEqual(total_extracted_entries, 4)

--- a/tests/unittests/test_request_timeout_v1.py
+++ b/tests/unittests/test_request_timeout_v1.py
@@ -17,7 +17,7 @@ class TestBackoffError(unittest.TestCase):
         client = ActiveCampaignClientV1("dummy_client_id", "dummy_client_secret", "dummy_refresh_token", 300)
         with self.assertRaises(Timeout):
             client.request("GET")
-        self.assertEquals(mock_request.call_count, 5)
+        self.assertEqual(mock_request.call_count, 5)
 
     @mock.patch('tap_activecampaign.client.requests.Session.request')
     def test_check_api_token_timeout_and_backoff(self, mocked_request):
@@ -40,7 +40,7 @@ class TestBackoffError(unittest.TestCase):
                 pass
         except Timeout:
             # verify that we backoff for 5 times
-            self.assertEquals(mocked_request.call_count, 5)
+            self.assertEqual(mocked_request.call_count, 5)
         
     @mock.patch('tap_activecampaign.client.requests.Session.request')
     def test_check_api_token_connection_error_and_backoff(self, mocked_request):
@@ -63,7 +63,7 @@ class TestBackoffError(unittest.TestCase):
                 pass
         except ConnectionError:
             # verify that we backoff for 5 times
-            self.assertEquals(mocked_request.call_count, 5)
+            self.assertEqual(mocked_request.call_count, 5)
 
 class MockResponse():
     '''


### PR DESCRIPTION
 Description of change
  
  AN-162: Add three new V1 campaign reporting streams — campaign_report_unopen_list, campaign_report_bounce_list, and campaign_report_unsubscription_list — following the existing campaign_report_open_list pattern. Each stream syncs incrementally per campaign ID (passed via extra_params.campaigns), uses page-based pagination against the ActiveCampaign V1 API, and applies the same 1-day bookmark overlap strategy.

  Manual QA steps

  - Add credentials and campaign IDs to config.json
  - Run discovery: tap-activecampaign --config config.json --discover > catalog.json
  - Confirm all three new streams appear in the catalog with correct key properties and replication keys
  - Select only the new streams in the catalog and run sync with state_20260605.json as the state file
  - Verify Singer RECORD messages are emitted for each stream with expected fields (tstamp, subscriberid, email, campaignid etc.)
  - Confirm state is written with an updated bookmark after sync completes

  Risks

  - The V1 API response structure is undocumented for edge cases; fields may differ across ActiveCampaign account configurations
  - campaign_report_bounce_list tstamp field returns date-only (YYYY-MM-DD) rather than datetime — downstream tooling should handle both formats

  Rollback steps

  - Revert this branch

  AI generated code

  https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
  - [x] this PR has been written with the help of GitHub Copilot or another generative AI tool

<img width="3259" height="395" alt="image" src="https://github.com/user-attachments/assets/8805d644-2bda-4a93-949d-ccf5b5e9b661" />
